### PR TITLE
fix TF issue 4151: azurerm_app_service blocks not working as expected

### DIFF
--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -87,7 +87,6 @@ func resourceArmAppService() *schema.Resource {
 			"connection_string": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -672,6 +672,39 @@ func TestAccAzureRMAppService_clientAffinityUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_removeAllConnectionStrings(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppService_connectionStrings(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.#", "2"),
+				),
+			},
+			{
+				Config: testAccAzureRMAppService_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppService_connectionStrings(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := tf.AccRandTimeInt()


### PR DESCRIPTION
After tested, I found this is a bug for resource “azurerm_app_service”. User expects the configuration should be removed from app service after removed the “connection_string” settings from tf config file. Actually it won’t remove the configuration. After checked, the root cause is that the connection_string field is defined the attribute “Computed: true”, which means terraform won’t check the difference for field connection_string when the field connection_string isn’t specified in tf config file. After tested, I found the configuration can be deleted successfully after removed the attribute. And this doc "https://www.terraform.io/docs/providers/azurerm/r/app_service.html#connection_string" also instruct the field connection_string should be optional. So I’ve provided the fix.